### PR TITLE
feat: Implement initial chunk rendering with basic blocks

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -433,6 +433,7 @@ version = "0.1.0"
 dependencies = [
  "bytemuck",
  "env_logger",
+ "glam",
  "pollster",
  "wgpu",
  "winit",
@@ -542,6 +543,12 @@ dependencies = [
  "log",
  "xml-rs",
 ]
+
+[[package]]
+name = "glam"
+version = "0.30.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50a99dbe56b72736564cfa4b85bf9a33079f16ae8b74983ab06af3b1a3696b11"
 
 [[package]]
 name = "glow"

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -9,3 +9,4 @@ env_logger = "0.11.8"
 pollster = "0.4.0"
 wgpu = "25.0.2"
 winit = "0.30.11"
+glam = "0.30.4" # For vector and matrix math

--- a/engine/src/block.rs
+++ b/engine/src/block.rs
@@ -1,0 +1,30 @@
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BlockType {
+    Air,    // Optional, for empty spaces
+    Dirt,
+    Grass,
+    // Add more block types here later if needed
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct Block {
+    pub block_type: BlockType,
+    // We can add more properties later, like light levels, custom data, etc.
+}
+
+impl Block {
+    pub fn new(block_type: BlockType) -> Self {
+        Block { block_type }
+    }
+
+    pub fn is_solid(&self) -> bool {
+        match self.block_type {
+            BlockType::Air => false,
+            _ => true, // All other current types are solid
+        }
+    }
+
+    // Later, we can add methods here to get texture coordinates
+    // based on BlockType and potentially block face.
+    // For now, we'll keep it simple.
+}

--- a/engine/src/camera.rs
+++ b/engine/src/camera.rs
@@ -1,0 +1,60 @@
+use glam::{Mat4, Vec3};
+
+pub struct Camera {
+    pub eye: Vec3,
+    pub target: Vec3,
+    pub up: Vec3,
+    pub aspect: f32,
+    pub fovy: f32, // Field of view in Y, in radians
+    pub znear: f32,
+    pub zfar: f32,
+}
+
+impl Camera {
+    pub fn new(
+        eye: Vec3,
+        target: Vec3,
+        up: Vec3,
+        aspect: f32,
+        fovy_degrees: f32,
+        znear: f32,
+        zfar: f32,
+    ) -> Self {
+        Self {
+            eye,
+            target,
+            up,
+            aspect,
+            fovy: fovy_degrees.to_radians(),
+            znear,
+            zfar,
+        }
+    }
+
+    pub fn build_view_projection_matrix(&self) -> Mat4 {
+        let view = Mat4::look_at_rh(self.eye, self.target, self.up);
+        let proj = Mat4::perspective_rh(self.fovy, self.aspect, self.znear, self.zfar);
+        proj * view
+    }
+}
+
+// We'll also define our Uniform struct here for now.
+// It needs to be `repr(C)` to ensure predictable memory layout for the shader.
+#[repr(C)]
+#[derive(Debug, Copy, Clone, bytemuck::Pod, bytemuck::Zeroable)]
+pub struct CameraUniform {
+    // Store as [[f32; 4]; 4] for bytemuck compatibility
+    view_proj: [[f32; 4]; 4],
+}
+
+impl CameraUniform {
+    pub fn new() -> Self {
+        Self {
+            view_proj: Mat4::IDENTITY.to_cols_array_2d(),
+        }
+    }
+
+    pub fn update_view_proj(&mut self, camera: &Camera) {
+        self.view_proj = camera.build_view_projection_matrix().to_cols_array_2d();
+    }
+}

--- a/engine/src/chunk.rs
+++ b/engine/src/chunk.rs
@@ -1,0 +1,67 @@
+use crate::block::{Block, BlockType}; // Assuming block.rs is in the same directory
+
+pub const CHUNK_WIDTH: usize = 16;
+pub const CHUNK_HEIGHT: usize = 32; // Reduced height for now
+pub const CHUNK_DEPTH: usize = 16;
+
+pub struct Chunk {
+    blocks: Vec<Vec<Vec<Block>>>, // Stored as [x][y][z]
+}
+
+impl Chunk {
+    pub fn new() -> Self {
+        // Initialize with Air blocks
+        let blocks = vec![
+            vec![
+                vec![Block::new(BlockType::Air); CHUNK_DEPTH];
+                CHUNK_HEIGHT
+            ];
+            CHUNK_WIDTH
+        ];
+        Chunk { blocks }
+    }
+
+    pub fn generate_terrain(&mut self) {
+        let surface_level = CHUNK_HEIGHT / 2; // Grass will be at this Y level
+
+        for x in 0..CHUNK_WIDTH {
+            for z in 0..CHUNK_DEPTH {
+                for y in 0..CHUNK_HEIGHT {
+                    if y < surface_level {
+                        self.blocks[x][y][z] = Block::new(BlockType::Dirt);
+                    } else if y == surface_level {
+                        self.blocks[x][y][z] = Block::new(BlockType::Grass);
+                    } // Above surface_level remains Air (as initialized)
+                }
+            }
+        }
+    }
+
+    // Helper to get a block at a given coordinate
+    // Returns Option<&Block> because coordinates might be out of bounds
+    pub fn get_block(&self, x: usize, y: usize, z: usize) -> Option<&Block> {
+        if x < CHUNK_WIDTH && y < CHUNK_HEIGHT && z < CHUNK_DEPTH {
+            Some(&self.blocks[x][y][z])
+        } else {
+            None
+        }
+    }
+
+    // Helper to set a block at a given coordinate
+    // Returns Result<(), &str> to indicate success or out-of-bounds error
+    pub fn set_block(&mut self, x: usize, y: usize, z: usize, block_type: BlockType) -> Result<(), &'static str> {
+        if x < CHUNK_WIDTH && y < CHUNK_HEIGHT && z < CHUNK_DEPTH {
+            self.blocks[x][y][z] = Block::new(block_type);
+            Ok(())
+        } else {
+            Err("Coordinates out of chunk bounds")
+        }
+    }
+}
+
+// Default implementation for Chunk, useful for initialization
+impl Default for Chunk {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/engine/src/cube_geometry.rs
+++ b/engine/src/cube_geometry.rs
@@ -1,0 +1,79 @@
+use crate::Vertex;
+
+// 8 corners of a cube, unit size centered at origin
+const CUBE_VERTICES_DATA: &[Vertex] = &[
+    // Front face (Z_NEGATIVE) - Assuming right-handed coordinates, +Y up, +X right, -Z into screen
+    // Vertex { position: [-0.5, -0.5, -0.5], color: [1.0, 0.0, 0.0] }, // 0: Bottom-left-front
+    // Vertex { position: [ 0.5, -0.5, -0.5], color: [1.0, 0.0, 0.0] }, // 1: Bottom-right-front
+    // Vertex { position: [ 0.5,  0.5, -0.5], color: [1.0, 0.0, 0.0] }, // 2: Top-right-front
+    // Vertex { position: [-0.5,  0.5, -0.5], color: [1.0, 0.0, 0.0] }, // 3: Top-left-front
+    // Back face (Z_POSITIVE)
+    // Vertex { position: [-0.5, -0.5,  0.5], color: [0.0, 1.0, 0.0] }, // 4: Bottom-left-back
+    // Vertex { position: [ 0.5, -0.5,  0.5], color: [0.0, 1.0, 0.0] }, // 5: Bottom-right-back
+    // Vertex { position: [ 0.5,  0.5,  0.5], color: [0.0, 1.0, 0.0] }, // 6: Top-right-back
+    // Vertex { position: [-0.5,  0.5,  0.5], color: [0.0, 1.0, 0.0] }, // 7: Top-left-back
+
+    // Let's define vertices per face to make UV mapping easier later if we add textures
+    // Each face will have 4 vertices. Colors are just placeholders for now.
+
+    // Front face (Z = -0.5)
+    Vertex { position: [-0.5, -0.5, -0.5], color: [1.0, 0.0, 0.0] }, // 0
+    Vertex { position: [ 0.5, -0.5, -0.5], color: [1.0, 0.0, 0.0] }, // 1
+    Vertex { position: [ 0.5,  0.5, -0.5], color: [1.0, 0.0, 0.0] }, // 2
+    Vertex { position: [-0.5,  0.5, -0.5], color: [1.0, 0.0, 0.0] }, // 3
+
+    // Back face (Z = 0.5)
+    Vertex { position: [-0.5, -0.5,  0.5], color: [0.0, 1.0, 0.0] }, // 4
+    Vertex { position: [ 0.5, -0.5,  0.5], color: [0.0, 1.0, 0.0] }, // 5
+    Vertex { position: [ 0.5,  0.5,  0.5], color: [0.0, 1.0, 0.0] }, // 6
+    Vertex { position: [-0.5,  0.5,  0.5], color: [0.0, 1.0, 0.0] }, // 7
+
+    // Right face (X = 0.5)
+    Vertex { position: [ 0.5, -0.5, -0.5], color: [0.0, 0.0, 1.0] }, // 8 (1)
+    Vertex { position: [ 0.5, -0.5,  0.5], color: [0.0, 0.0, 1.0] }, // 9 (5)
+    Vertex { position: [ 0.5,  0.5,  0.5], color: [0.0, 0.0, 1.0] }, // 10 (6)
+    Vertex { position: [ 0.5,  0.5, -0.5], color: [0.0, 0.0, 1.0] }, // 11 (2)
+
+    // Left face (X = -0.5)
+    Vertex { position: [-0.5, -0.5,  0.5], color: [1.0, 1.0, 0.0] }, // 12 (4)
+    Vertex { position: [-0.5, -0.5, -0.5], color: [1.0, 1.0, 0.0] }, // 13 (0)
+    Vertex { position: [-0.5,  0.5, -0.5], color: [1.0, 1.0, 0.0] }, // 14 (3)
+    Vertex { position: [-0.5,  0.5,  0.5], color: [1.0, 1.0, 0.0] }, // 15 (7)
+
+    // Top face (Y = 0.5)
+    Vertex { position: [-0.5,  0.5, -0.5], color: [1.0, 0.0, 1.0] }, // 16 (3)
+    Vertex { position: [ 0.5,  0.5, -0.5], color: [1.0, 0.0, 1.0] }, // 17 (2)
+    Vertex { position: [ 0.5,  0.5,  0.5], color: [1.0, 0.0, 1.0] }, // 18 (6)
+    Vertex { position: [-0.5,  0.5,  0.5], color: [1.0, 0.0, 1.0] }, // 19 (7)
+
+    // Bottom face (Y = -0.5)
+    Vertex { position: [-0.5, -0.5,  0.5], color: [0.0, 1.0, 1.0] }, // 20 (4)
+    Vertex { position: [ 0.5, -0.5,  0.5], color: [0.0, 1.0, 1.0] }, // 21 (5)
+    Vertex { position: [ 0.5, -0.5, -0.5], color: [0.0, 1.0, 1.0] }, // 22 (1)
+    Vertex { position: [-0.5, -0.5, -0.5], color: [0.0, 1.0, 1.0] }, // 23 (0)
+];
+
+// Indices for 24 vertices (6 faces * 4 vertices per face)
+// Each face is two triangles (3 indices * 2 = 6 indices per face)
+// 6 faces * 6 indices/face = 36 indices
+const CUBE_INDICES_DATA: &[u16] = &[
+    0, 1, 2,  0, 2, 3,    // Front
+    4, 5, 6,  4, 6, 7,    // Back
+    8, 9, 10, 8, 10, 11,   // Right
+    12, 13, 14, 12, 14, 15, // Left
+    16, 17, 18, 16, 18, 19, // Top
+    20, 21, 22, 20, 22, 23, // Bottom
+];
+
+
+pub fn cube_vertices() -> &'static [Vertex] {
+    CUBE_VERTICES_DATA
+}
+
+pub fn cube_indices() -> &'static [u16] {
+    CUBE_INDICES_DATA
+}
+
+// Later we will add functions to get texture coordinates too.
+// For now, color is part of Vertex.
+// pub fn get_face_texture_coordinates(face_index: usize) -> &'static [[f32; 2]; 4] { ... }

--- a/engine/src/instance.rs
+++ b/engine/src/instance.rs
@@ -1,0 +1,68 @@
+use glam::Mat4;
+
+#[repr(C)]
+#[derive(Copy, Clone, Debug, bytemuck::Pod, bytemuck::Zeroable)]
+pub struct InstanceRaw {
+    // Using separate components for model matrix to avoid potential padding issues with Mat4 directly.
+    // Alternatively, ensure Mat4 is correctly Pod. glam::Mat4 should be fine, but this is explicit.
+    model_matrix_col_0: [f32; 4],
+    model_matrix_col_1: [f32; 4],
+    model_matrix_col_2: [f32; 4],
+    model_matrix_col_3: [f32; 4],
+    color: [f32; 3], // R, G, B
+    _padding: f32, // Ensure alignment for next instance if necessary (vec3 is 12 bytes, mat4 is 64)
+                   // A single f32 here makes InstanceRaw 16*4 + 12 + 4 = 64 + 16 = 80 bytes.
+                   // This should be fine. If issues, align to 16 bytes multiple if colors were vec4.
+}
+
+impl InstanceRaw {
+    pub fn new(model_matrix: Mat4, color: [f32; 3]) -> Self {
+        Self {
+            model_matrix_col_0: model_matrix.x_axis.into(), // Column 0
+            model_matrix_col_1: model_matrix.y_axis.into(), // Column 1
+            model_matrix_col_2: model_matrix.z_axis.into(), // Column 2
+            model_matrix_col_3: model_matrix.w_axis.into(), // Column 3
+            color,
+            _padding: 0.0,
+        }
+    }
+
+    pub fn desc() -> wgpu::VertexBufferLayout<'static> {
+        use std::mem;
+        wgpu::VertexBufferLayout {
+            array_stride: mem::size_of::<InstanceRaw>() as wgpu::BufferAddress,
+            // This attribute describes data that changes per instance.
+            step_mode: wgpu::VertexStepMode::Instance,
+            attributes: &[
+                // Model Matrix (mat4x4<f32>) is passed as four vec4<f32> attributes
+                // Shader location 5, 6, 7, 8 (assuming vertex attributes use 0-4)
+                wgpu::VertexAttribute { // Column 0
+                    offset: 0,
+                    shader_location: 5,
+                    format: wgpu::VertexFormat::Float32x4,
+                },
+                wgpu::VertexAttribute { // Column 1
+                    offset: mem::size_of::<[f32; 4]>() as wgpu::BufferAddress,
+                    shader_location: 6,
+                    format: wgpu::VertexFormat::Float32x4,
+                },
+                wgpu::VertexAttribute { // Column 2
+                    offset: mem::size_of::<[f32; 8]>() as wgpu::BufferAddress,
+                    shader_location: 7,
+                    format: wgpu::VertexFormat::Float32x4,
+                },
+                wgpu::VertexAttribute { // Column 3
+                    offset: mem::size_of::<[f32; 12]>() as wgpu::BufferAddress,
+                    shader_location: 8,
+                    format: wgpu::VertexFormat::Float32x4,
+                },
+                // Color attribute
+                wgpu::VertexAttribute {
+                    offset: mem::size_of::<[f32; 16]>() as wgpu::BufferAddress, // after 4 vec4s for matrix
+                    shader_location: 9, // Next available location
+                    format: wgpu::VertexFormat::Float32x3, // For RGB color
+                },
+            ],
+        }
+    }
+}


### PR DESCRIPTION
Implemented rendering for a single 16x32x16 chunk of blocks, displaying dirt with a layer of grass on top.

Key features and changes:
- Defined Block and BlockType (Air, Dirt, Grass).
- Created a Chunk data structure to hold blocks.
- Implemented terrain generation for a simple dirt/grass layout.
- Set up cube geometry (vertices and indices).
- Integrated glam for 3D math (camera, matrices).
- Implemented a camera with perspective projection.
- Updated WGPU rendering pipeline for 3D and instancing.
- Shader updated for MVP transformations and per-instance data.
- Used instanced rendering to draw multiple blocks efficiently.
- Added block-specific colors (brown for dirt, green for grass).
- Enabled depth testing for correct 3D ordering.
- Enabled backface culling.
- Adjusted initial camera position for a better view of the chunk.
- Updated glam dependency to 0.30.4.
- Resolved build errors related to module imports and bytemuck trait implementations for glam::Mat4 in UBOs.

Known issues/Future work:
- No interactive camera controls.
- `Chunk::set_block` is currently unused.
- Textures are not yet implemented (using solid colors).