### PR TITLE
feat: Add GitHub Actions workflow for Linux and Windows builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,61 @@
+name: Build Executables
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build-linux:
+    name: Build for Linux
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./engine
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Install Rust toolchain
+      uses: actions-rust-lang/setup-rust-toolchain@v1
+      with:
+        toolchain: stable
+
+    - name: Install Linux dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y libvulkan-dev libxkbcommon-dev libwayland-dev libgtk-3-dev libudev-dev pkg-config
+
+    - name: Build release executable (Linux)
+      run: cargo build --release --verbose
+
+    - name: Archive Linux executable
+      uses: actions/upload-artifact@v4
+      with:
+        name: engine-linux
+        path: engine/target/release/engine
+
+  build-windows:
+    name: Build for Windows
+    runs-on: windows-latest
+    defaults:
+      run:
+        working-directory: ./engine
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Install Rust toolchain
+      uses: actions-rust-lang/setup-rust-toolchain@v1
+      with:
+        toolchain: stable
+
+    - name: Build release executable (Windows)
+      run: cargo build --release --verbose
+
+    - name: Archive Windows executable
+      uses: actions/upload-artifact@v4
+      with:
+        name: engine-windows
+        path: engine/target/release/engine.exe


### PR DESCRIPTION
This workflow builds the Rust project in the `engine` directory for both Ubuntu and Windows.

It includes steps for:
- Checking out the code
- Setting up the Rust toolchain
- Installing necessary dependencies for wgpu on Linux
- Building the release executable
- Uploading the compiled executables as artifacts.