### PR TITLE
Fix: Correct swapped left and right player movement

### DIFF
--- a/engine/src/player.rs
+++ b/engine/src/player.rs
@@ -102,10 +102,10 @@ impl Player {
 
 
         if self.movement_intention.left {
-            intended_horizontal_velocity -= horizontal_right;
+            intended_horizontal_velocity += horizontal_right;
         }
         if self.movement_intention.right {
-            intended_horizontal_velocity += horizontal_right;
+            intended_horizontal_velocity -= horizontal_right;
         }
 
         if intended_horizontal_velocity.length_squared() > 0.0 {


### PR DESCRIPTION
Swapped the logic for left and right player movement to ensure that pressing 'A' moves the player left and 'D' moves the player right.