### PR TITLE
Fix: Configure wgpu_text pipeline with depth format

### DIFF
--- a/engine/src/debug_overlay.rs
+++ b/engine/src/debug_overlay.rs
@@ -4,6 +4,7 @@ use wgpu_text::{
     BrushBuilder,
     TextBrush,
 };
+use wgpu::TextureFormat; // Import TextureFormat
 use std::time::Instant;
 use glam::Vec3;
 
@@ -27,6 +28,13 @@ impl DebugOverlay {
     pub fn new(device: &wgpu::Device, config: &wgpu::SurfaceConfiguration) -> Self {
         let font = FontArc::try_from_slice(FONT_BYTES).expect("Failed to load font. Make sure Roboto-Regular.ttf is in the correct location.");
         let brush = BrushBuilder::using_font(font.clone())
+            .with_depth_stencil(Some(wgpu::DepthStencilState {
+                format: TextureFormat::Depth32Float,
+                depth_write_enabled: true, // Text should probably write to depth buffer
+                depth_compare: wgpu::CompareFunction::Less, // Match main pipeline's comparison
+                stencil: wgpu::StencilState::default(),
+                bias: wgpu::DepthBiasState::default(),
+            }))
             .build(device, config.width, config.height, config.format);
 
         // We don't need to prefix with a module name here because we `use`d them directly


### PR DESCRIPTION
The wgpu_text render pipeline was not configured with a depth-stencil format, causing a conflict with the main render pass which expects one.

This change updates the DebugOverlay to initialize the TextBrush with the correct DepthStencilState, matching the Depth32Float format and comparison function used by the main render pass.