### PR TITLE
Fix: Debug overlay F3 toggle now works correctly

### DIFF
--- a/engine/src/main.rs
+++ b/engine/src/main.rs
@@ -669,8 +669,10 @@ impl State {
                     }
                     KeyCode::Escape => false, // Escape is handled by App for mouse grab
                     KeyCode::F3 => {
-                        self.debug_overlay.toggle_visibility();
-                        true // Event handled
+                        if is_pressed { // Only toggle on press
+                            self.debug_overlay.toggle_visibility();
+                        }
+                        true // Event handled regardless of press/release to consume it
                     }
                     _ => false,
                 }


### PR DESCRIPTION
The debug overlay visibility was previously toggled on both press and release of the F3 key, effectively making the toggle appear broken. This change ensures the toggle only occurs on the key press event.