### PR TITLE
Fix: Correct grass block side texture orientation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,7 +46,7 @@ This section should be updated as we make progress.
   * **World / Chunk:**
     * A single chunk with a flat terrain of dirt and grass is generated.
     * Mesh generation includes basic culling of hidden faces.
-  * **Current Task Focus:** The crosshair implementation is complete. Next steps could involve refining player physics (e.g., implementing "collide and slide"), starting procedural world generation, or adding texture mapping.
+  * **Current Task Focus:** Grass block side texture orientation has been corrected. Next steps could involve refining player physics (e.g., implementing "collide and slide") or starting procedural world generation.
 
 ## 3. Best Practices for Interaction
 
@@ -81,7 +81,7 @@ This is our high-level plan. We will tackle these items one by one.
     * [x] Implement gravity and velocity.
     * [/] Implement "collide and stop" physics (slide mechanics pending).
 2.  **Visuals & World**
-    * [ ] Texture blocks using a texture atlas.
+    * [x] Texture blocks using a texture atlas. (Grass block side texture orientation fixed)
     * [ ] Implement procedural world generation with a noise function. (Current generation is flat)
 3.  **Interaction**
     * [ ] Implement raycasting for block selection.

--- a/engine/src/main.rs
+++ b/engine/src/main.rs
@@ -777,12 +777,29 @@ impl State {
                                     let u_max = u_min + tex_size_x;
                                     let v_max = v_min + tex_size_y;
 
-                                    let face_uvs = [
-                                        [u_min, v_max],
-                                        [u_max, v_max],
-                                        [u_max, v_min],
-                                        [u_min, v_min],
+                                    // Define the two potential UV mappings based on face vertex order
+                                    let uvs_for_bl_br_tr_tl_order = [ // Used for Back, Top
+                                        [u_min, v_max], // BL_tex for V0 (BL_vert)
+                                        [u_max, v_max], // BR_tex for V1 (BR_vert)
+                                        [u_max, v_min], // TR_tex for V2 (TR_vert)
+                                        [u_min, v_min], // TL_tex for V3 (TL_vert)
                                     ];
+
+                                    let uvs_for_bl_tl_tr_br_order = [ // Used for Front, Right, Left, Bottom
+                                        [u_min, v_max], // BL_tex for V0 (BL_vert)
+                                        [u_min, v_min], // TL_tex for V1 (TL_vert)
+                                        [u_max, v_min], // TR_tex for V2 (TR_vert)
+                                        [u_max, v_max], // BR_tex for V3 (BR_vert)
+                                    ];
+
+                                    let selected_face_uvs = match face_type {
+                                        CubeFace::Front | CubeFace::Right | CubeFace::Left | CubeFace::Bottom => {
+                                            &uvs_for_bl_tl_tr_br_order
+                                        }
+                                        CubeFace::Back | CubeFace::Top => {
+                                            &uvs_for_bl_br_tr_tl_order
+                                        }
+                                    };
 
                                     for (i, v_template) in vertices_template.iter().enumerate() {
                                         chunk_mesh_vertices.push(Vertex {
@@ -790,7 +807,7 @@ impl State {
                                                 + glam::Vec3::from(v_template.position))
                                             .into(),
                                             color: current_vertex_color,
-                                            uv: face_uvs[i],
+                                            uv: selected_face_uvs[i],
                                         });
                                     }
                                     for local_idx in local_indices {


### PR DESCRIPTION
The previous UV mapping for cube faces resulted in grass side textures being incorrectly rotated on three out of four sides. This change introduces conditional UV mapping based on the specific CubeFace type, ensuring that the vertex order of the face template aligns with the UV coordinates to render the texture upright.

- Modified `State::build_or_rebuild_chunk_mesh` in `engine/src/main.rs`.
- Introduced two UV mapping arrays: `uvs_for_bl_br_tr_tl_order` (for Back, Top faces) and `uvs_for_bl_tl_tr_br_order` (for Front, Right, Left, Bottom faces).
- The correct UV map is now selected based on `face_type` before assigning UVs to vertices.
- Updated AGENTS.md to reflect this change.