### PR TITLE
Add bedrock block type and functionality

### DIFF
--- a/engine/src/block.rs
+++ b/engine/src/block.rs
@@ -3,6 +3,7 @@ pub enum BlockType {
     Air,    // Optional, for empty spaces
     Dirt,
     Grass,
+    Bedrock,
     // Add more block types here later if needed
 }
 
@@ -27,4 +28,21 @@ impl Block {
     // Later, we can add methods here to get texture coordinates
     // based on BlockType and potentially block face.
     // For now, we'll keep it simple.
+
+    // Returns atlas indices (column, row) for each face: [Front, Back, Right, Left, Top, Bottom]
+    pub fn get_texture_atlas_indices(&self) -> [[f32; 2]; 6] {
+        match self.block_type {
+            BlockType::Dirt => [[2.0, 0.0]; 6], // Dirt texture at (2,0) in terrain.png
+            BlockType::Grass => [
+                [3.0, 0.0], // Front (Grass Side)
+                [3.0, 0.0], // Back (Grass Side)
+                [3.0, 0.0], // Right (Grass Side)
+                [3.0, 0.0], // Left (Grass Side)
+                [0.0, 0.0], // Top (Grass Top)
+                [2.0, 0.0], // Bottom (Dirt)
+            ],
+            BlockType::Bedrock => [[1.0, 1.0]; 6], // Bedrock at (1,1)
+            BlockType::Air => [[15.0, 15.0]; 6], // Default/error texture (far corner of atlas)
+        }
+    }
 }

--- a/engine/src/chunk.rs
+++ b/engine/src/chunk.rs
@@ -25,7 +25,10 @@ impl Chunk {
 
         for x in 0..CHUNK_WIDTH {
             for z in 0..CHUNK_DEPTH {
-                for y in 0..CHUNK_HEIGHT {
+                // Place bedrock at y = 0
+                self.blocks[x][0][z] = Block::new(BlockType::Bedrock);
+
+                for y in 1..CHUNK_HEIGHT { // Start from y = 1 since y = 0 is bedrock
                     if y < surface_level {
                         self.blocks[x][y][z] = Block::new(BlockType::Dirt);
                     } else if y == surface_level {

--- a/engine/src/main.rs
+++ b/engine/src/main.rs
@@ -691,6 +691,7 @@ impl State {
                             let default_block_color = match block.block_type {
                                 crate::block::BlockType::Dirt => [0.5, 0.25, 0.05],
                                 crate::block::BlockType::Grass => [0.0, 0.8, 0.1], // Default grass color
+                                crate::block::BlockType::Bedrock => [0.5, 0.5, 0.5], // Default bedrock color
                                 crate::block::BlockType::Air => continue,
                             };
 
@@ -740,40 +741,44 @@ impl State {
                                     let tex_size_x = 1.0 / ATLAS_COLS;
                                     let tex_size_y = 1.0 / ATLAS_ROWS;
 
-                                    let tex_coords_idx: (f32, f32); // Removed mut
-                                    let mut current_vertex_color: [f32; 3];
+                                    let all_face_atlas_indices = block.get_texture_atlas_indices();
+                                    let mut current_vertex_color = default_block_color; // Start with default from outer match
 
-                                    match block.block_type {
-                                        crate::block::BlockType::Grass => {
-                                            current_vertex_color = [0.0, 0.8, 0.1]; // Default for grass sides
-                                            match face_type {
-                                                CubeFace::Top => {
-                                                    tex_coords_idx = (0.0, 0.0); // Grass Top (grayscale)
-                                                    current_vertex_color = [0.1, 0.9, 0.1]; // Sentinel for tinting
-                                                }
-                                                CubeFace::Bottom => {
-                                                    tex_coords_idx = (2.0, 0.0); // Dirt texture
-                                                    current_vertex_color = [0.5, 0.25, 0.05]; // Standard Dirt color
-                                                }
-                                                _ => {
-                                                    // Sides
-                                                    tex_coords_idx = (3.0, 0.0); // Grass Side texture
-                                                    // current_vertex_color remains [0.0, 0.8, 0.1] (standard grass color)
-                                                }
-                                            }
-                                        }
-                                        crate::block::BlockType::Dirt => {
-                                            tex_coords_idx = (2.0, 0.0); // Dirt texture
-                                            current_vertex_color = [0.5, 0.25, 0.05]; // Standard Dirt color
-                                        }
-                                        _ => {
-                                            tex_coords_idx = (15.0, 15.0);
-                                            current_vertex_color = default_block_color;
-                                        }
+                                    let face_specific_atlas_indices: [f32; 2] = match face_type {
+                                        CubeFace::Front => all_face_atlas_indices[0],
+                                        CubeFace::Back => all_face_atlas_indices[1],
+                                        CubeFace::Right => all_face_atlas_indices[2],
+                                        CubeFace::Left => all_face_atlas_indices[3],
+                                        CubeFace::Top => all_face_atlas_indices[4],
+                                        CubeFace::Bottom => all_face_atlas_indices[5],
                                     };
 
-                                    let u_min = tex_coords_idx.0 * tex_size_x;
-                                    let v_min = tex_coords_idx.1 * tex_size_y;
+                                    // Apply specific color changes after selecting texture, using default_block_color as a base
+                                    match block.block_type {
+                                        crate::block::BlockType::Grass => {
+                                            if *face_type == CubeFace::Top {
+                                                current_vertex_color = [0.1, 0.9, 0.1]; // Sentinel for tinting grass top
+                                            } else if *face_type == CubeFace::Bottom {
+                                                // Bottom of grass uses Dirt texture (already set by all_face_atlas_indices)
+                                                // and should have dirt color
+                                                current_vertex_color = [0.5, 0.25, 0.05];
+                                            } else {
+                                                // Sides of grass
+                                                current_vertex_color = [0.0, 0.8, 0.1];
+                                            }
+                                        }
+                                        crate::block::BlockType::Bedrock => {
+                                            // Bedrock uses its specific texture (set by all_face_atlas_indices)
+                                            // and its default color was already set by the outer match
+                                            // current_vertex_color = [0.4, 0.4, 0.4]; // Or a specific color if different from default
+                                        }
+                                        // Dirt's color is already set by default_block_color
+                                        // Air is skipped earlier
+                                        _ => {}
+                                    }
+
+                                    let u_min = face_specific_atlas_indices[0] * tex_size_x;
+                                    let v_min = face_specific_atlas_indices[1] * tex_size_y;
                                     let u_max = u_min + tex_size_x;
                                     let v_max = v_min + tex_size_y;
 
@@ -1020,21 +1025,24 @@ impl State {
             if let Some((block_pos, _face)) = self.selected_block {
                 match self.world.set_block(block_pos, BlockType::Air) {
                     Ok(chunk_coord) => {
+                        // Mark chunk as dirty by removing its render data
                         self.chunk_render_data.remove(&chunk_coord);
-                        self.build_or_rebuild_chunk_mesh(chunk_coord.0, chunk_coord.1);
+                        // Also, if the removed block was on a boundary, the adjacent chunk might need updating
+                        // This is complex; for now, just rebuild the primary chunk.
+                        // A more robust solution would check neighbors if block is on edge.
+                        // We might also need to rebuild neighbors if a block *removal* exposes their faces.
+                        // For simplicity, we'll rely on the existing active chunk meshing logic to pick up
+                        // changes when the player moves, or we can force rebuilds of neighbors.
+                        // Let's check and rebuild neighbors of the modified chunk as well.
+                        self.build_or_rebuild_chunk_mesh(chunk_coord.0, chunk_coord.1); // Rebuild the main chunk
+                        // And its direct neighbors, as face visibility might change
                         self.build_or_rebuild_chunk_mesh(chunk_coord.0 + 1, chunk_coord.1);
                         self.build_or_rebuild_chunk_mesh(chunk_coord.0 - 1, chunk_coord.1);
                         self.build_or_rebuild_chunk_mesh(chunk_coord.0, chunk_coord.1 + 1);
                         self.build_or_rebuild_chunk_mesh(chunk_coord.0, chunk_coord.1 - 1);
                     }
-                    Err(crate::world::SetBlockError::IsBedrock) => { // Qualified path
-                        // Silent no-op for trying to mine bedrock
-                    }
-                    Err(crate::world::SetBlockError::OutOfBounds) => { // Qualified path
-                        eprintln!("Error removing block: Out of bounds");
-                    }
-                    Err(crate::world::SetBlockError::ChunkUpdateFailed(e)) => { // Qualified path
-                        eprintln!("Error removing block - chunk update failed: {}", e);
+                    Err(e) => {
+                        eprintln!("Error removing block: {}", e);
                     }
                 }
             }
@@ -1042,6 +1050,7 @@ impl State {
 
         // Block Placement (Right-Click)
         if self.input_state.right_mouse_pressed_this_frame {
+            // Use self.input_state
             if let Some((selected_block_pos, hit_face)) = self.selected_block {
                 let mut offset = IVec3::ZERO;
                 match hit_face {
@@ -1054,32 +1063,29 @@ impl State {
                 }
                 let new_block_pos = selected_block_pos + offset;
 
+                // Collision Check with player
                 let player_aabb = self.player.get_world_bounding_box();
                 let new_block_aabb = AABB {
                     min: new_block_pos.as_vec3(),
-                    max: new_block_pos.as_vec3() + glam::Vec3::ONE,
+                    max: new_block_pos.as_vec3() + glam::Vec3::ONE, // Assuming 1x1x1 block
                 };
 
                 if player_aabb.intersects(&new_block_aabb) {
                     // eprintln!("Cannot place block: intersects with player.");
                 } else {
-                    match self.world.set_block(new_block_pos, BlockType::Grass) { // TODO: Use selected block type from inventory
+                    match self.world.set_block(new_block_pos, BlockType::Grass) {
                         Ok(chunk_coord) => {
+                            // Mark chunk as dirty by removing its render data
                             self.chunk_render_data.remove(&chunk_coord);
+                            // Rebuild the potentially new chunk and its neighbors
                             self.build_or_rebuild_chunk_mesh(chunk_coord.0, chunk_coord.1);
                             self.build_or_rebuild_chunk_mesh(chunk_coord.0 + 1, chunk_coord.1);
                             self.build_or_rebuild_chunk_mesh(chunk_coord.0 - 1, chunk_coord.1);
                             self.build_or_rebuild_chunk_mesh(chunk_coord.0, chunk_coord.1 + 1);
                             self.build_or_rebuild_chunk_mesh(chunk_coord.0, chunk_coord.1 - 1);
                         }
-                        Err(crate::world::SetBlockError::IsBedrock) => { // Qualified path
-                            eprintln!("Error placing block: Target is Bedrock (should be rare)");
-                        }
-                        Err(crate::world::SetBlockError::OutOfBounds) => { // Qualified path
-                            eprintln!("Error placing block: Out of bounds");
-                        }
-                        Err(crate::world::SetBlockError::ChunkUpdateFailed(e)) => { // Qualified path
-                            eprintln!("Error placing block - chunk update failed: {}", e);
+                        Err(e) => {
+                            eprintln!("Error placing block: {}", e);
                         }
                     }
                 }

--- a/engine/src/main.rs
+++ b/engine/src/main.rs
@@ -741,40 +741,44 @@ impl State {
                                     let tex_size_x = 1.0 / ATLAS_COLS;
                                     let tex_size_y = 1.0 / ATLAS_ROWS;
 
-                                    let tex_coords_idx: (f32, f32); // Removed mut
-                                    let mut current_vertex_color: [f32; 3];
+                                    let all_face_atlas_indices = block.get_texture_atlas_indices();
+                                    let mut current_vertex_color = default_block_color; // Start with default from outer match
 
-                                    match block.block_type {
-                                        crate::block::BlockType::Grass => {
-                                            current_vertex_color = [0.0, 0.8, 0.1]; // Default for grass sides
-                                            match face_type {
-                                                CubeFace::Top => {
-                                                    tex_coords_idx = (0.0, 0.0); // Grass Top (grayscale)
-                                                    current_vertex_color = [0.1, 0.9, 0.1]; // Sentinel for tinting
-                                                }
-                                                CubeFace::Bottom => {
-                                                    tex_coords_idx = (2.0, 0.0); // Dirt texture
-                                                    current_vertex_color = [0.5, 0.25, 0.05]; // Standard Dirt color
-                                                }
-                                                _ => {
-                                                    // Sides
-                                                    tex_coords_idx = (3.0, 0.0); // Grass Side texture
-                                                    // current_vertex_color remains [0.0, 0.8, 0.1] (standard grass color)
-                                                }
-                                            }
-                                        }
-                                        crate::block::BlockType::Dirt => {
-                                            tex_coords_idx = (2.0, 0.0); // Dirt texture
-                                            current_vertex_color = [0.5, 0.25, 0.05]; // Standard Dirt color
-                                        }
-                                        _ => {
-                                            tex_coords_idx = (15.0, 15.0);
-                                            current_vertex_color = default_block_color;
-                                        }
+                                    let face_specific_atlas_indices: [f32; 2] = match face_type {
+                                        CubeFace::Front => all_face_atlas_indices[0],
+                                        CubeFace::Back => all_face_atlas_indices[1],
+                                        CubeFace::Right => all_face_atlas_indices[2],
+                                        CubeFace::Left => all_face_atlas_indices[3],
+                                        CubeFace::Top => all_face_atlas_indices[4],
+                                        CubeFace::Bottom => all_face_atlas_indices[5],
                                     };
 
-                                    let u_min = tex_coords_idx.0 * tex_size_x;
-                                    let v_min = tex_coords_idx.1 * tex_size_y;
+                                    // Apply specific color changes after selecting texture, using default_block_color as a base
+                                    match block.block_type {
+                                        crate::block::BlockType::Grass => {
+                                            if *face_type == CubeFace::Top {
+                                                current_vertex_color = [0.1, 0.9, 0.1]; // Sentinel for tinting grass top
+                                            } else if *face_type == CubeFace::Bottom {
+                                                // Bottom of grass uses Dirt texture (already set by all_face_atlas_indices)
+                                                // and should have dirt color
+                                                current_vertex_color = [0.5, 0.25, 0.05];
+                                            } else {
+                                                // Sides of grass
+                                                current_vertex_color = [0.0, 0.8, 0.1];
+                                            }
+                                        }
+                                        crate::block::BlockType::Bedrock => {
+                                            // Bedrock uses its specific texture (set by all_face_atlas_indices)
+                                            // and its default color was already set by the outer match
+                                            // current_vertex_color = [0.4, 0.4, 0.4]; // Or a specific color if different from default
+                                        }
+                                        // Dirt's color is already set by default_block_color
+                                        // Air is skipped earlier
+                                        _ => {}
+                                    }
+
+                                    let u_min = face_specific_atlas_indices[0] * tex_size_x;
+                                    let v_min = face_specific_atlas_indices[1] * tex_size_y;
                                     let u_max = u_min + tex_size_x;
                                     let v_max = v_min + tex_size_y;
 

--- a/engine/src/main.rs
+++ b/engine/src/main.rs
@@ -691,6 +691,7 @@ impl State {
                             let default_block_color = match block.block_type {
                                 crate::block::BlockType::Dirt => [0.5, 0.25, 0.05],
                                 crate::block::BlockType::Grass => [0.0, 0.8, 0.1], // Default grass color
+                                crate::block::BlockType::Bedrock => [0.5, 0.5, 0.5], // Default bedrock color
                                 crate::block::BlockType::Air => continue,
                             };
 

--- a/engine/src/world.rs
+++ b/engine/src/world.rs
@@ -79,6 +79,15 @@ impl World {
             return Err("Calculated local Y coordinate out of chunk bounds");
         }
 
+        // Check if the block being replaced is Bedrock
+        if let Some(chunk) = self.get_chunk(chunk_x, chunk_z) {
+            if let Some(existing_block) = chunk.get_block(local_x, local_y, local_z) {
+                if existing_block.block_type == crate::block::BlockType::Bedrock {
+                    return Err("Cannot replace Bedrock");
+                }
+            }
+        }
+
         let chunk = self.get_or_create_chunk(chunk_x, chunk_z);
         match chunk.set_block(local_x, local_y, local_z, block_type) {
             Ok(_) => Ok((chunk_x, chunk_z)),

--- a/engine/src/world.rs
+++ b/engine/src/world.rs
@@ -2,6 +2,13 @@ use std::collections::HashMap;
 use crate::chunk::{Chunk, CHUNK_WIDTH, CHUNK_HEIGHT, CHUNK_DEPTH};
 use crate::block::Block; // Removed BlockType as it's unused
 
+#[derive(Debug, PartialEq)] // Added derive for Debug and PartialEq
+pub enum SetBlockError {
+    OutOfBounds,
+    IsBedrock,
+    ChunkUpdateFailed(&'static str),
+}
+
 pub struct World {
     chunks: HashMap<(i32, i32), Chunk>,
 }
@@ -64,9 +71,9 @@ impl World {
     // pub fn set_block_at_world(&mut self, world_x: f32, world_y: f32, world_z: f32, block_type: BlockType) -> Result<(), &'static str> { // Old signature
     // New set_block method using IVec3 and returning modified chunk coordinates
     // Returns the world chunk coordinates (cx, cz) of the modified chunk if successful.
-    pub fn set_block(&mut self, world_block_pos: glam::IVec3, block_type: crate::block::BlockType) -> Result<(i32, i32), &'static str> {
+    pub fn set_block(&mut self, world_block_pos: glam::IVec3, block_type: crate::block::BlockType) -> Result<(i32, i32), SetBlockError> {
         if world_block_pos.y < 0 || world_block_pos.y >= CHUNK_HEIGHT as i32 {
-            return Err("Y coordinate out of world bounds");
+            return Err(SetBlockError::OutOfBounds);
         }
 
         let ((chunk_x, chunk_z), (local_x, local_y, local_z)) =
@@ -76,22 +83,26 @@ impl World {
         if local_y >= CHUNK_HEIGHT {
              // This case should ideally not be hit if the initial Y check is correct
              // and world_to_chunk_coords handles y correctly.
-            return Err("Calculated local Y coordinate out of chunk bounds");
+            return Err(SetBlockError::OutOfBounds);
         }
 
         // Check if the block being replaced is Bedrock
-        if let Some(chunk) = self.get_chunk(chunk_x, chunk_z) {
-            if let Some(existing_block) = chunk.get_block(local_x, local_y, local_z) {
-                if existing_block.block_type == crate::block::BlockType::Bedrock {
-                    return Err("Cannot replace Bedrock");
+        // Need to get the chunk first (without creating it if it doesn't exist for a read-only check)
+        if let Some(chunk_ro) = self.get_chunk(chunk_x, chunk_z) { // Read-only access
+            if let Some(existing_block) = chunk_ro.get_block(local_x, local_y, local_z) {
+                if existing_block.block_type == crate::block::BlockType::Bedrock && block_type != crate::block::BlockType::Bedrock { // Allow placing bedrock on bedrock (e.g. world gen)
+                    return Err(SetBlockError::IsBedrock);
                 }
             }
         }
+        // If the chunk doesn't exist yet, get_or_create_chunk will generate it,
+        // including the bedrock layer at y=0. If the attempt is to modify y=0
+        // to non-Bedrock, the above check will eventually catch it after chunk creation.
 
         let chunk = self.get_or_create_chunk(chunk_x, chunk_z);
         match chunk.set_block(local_x, local_y, local_z, block_type) {
             Ok(_) => Ok((chunk_x, chunk_z)),
-            Err(e) => Err(e), // Propagate error from chunk.set_block
+            Err(e) => Err(SetBlockError::ChunkUpdateFailed(e)), // Propagate error from chunk.set_block
         }
     }
 }


### PR DESCRIPTION
- Added Bedrock to BlockType enum.
- Defined texture coordinates for Bedrock (atlas index 1,1).
- Updated chunk generation to place a layer of Bedrock at y=0.
- Made Bedrock unmineable by preventing its replacement in World::set_block.
- Adjusted texture coordinate handling in main.rs to use atlas indices from Block::get_texture_atlas_indices.