### PR TITLE
Implement static sunlight and basic cave darkness

### DIFF
--- a/engine/src/block.rs
+++ b/engine/src/block.rs
@@ -12,12 +12,16 @@ pub enum BlockType {
 #[derive(Debug, Clone, Copy)]
 pub struct Block {
     pub block_type: BlockType,
+    pub light_level: u8, // Added light_level
     // We can add more properties later, like light levels, custom data, etc.
 }
 
 impl Block {
     pub fn new(block_type: BlockType) -> Self {
-        Block { block_type }
+        Block {
+            block_type,
+            light_level: 0, // Initialize light_level to 0
+        }
     }
 
     pub fn is_solid(&self) -> bool {

--- a/engine/src/chunk.rs
+++ b/engine/src/chunk.rs
@@ -4,10 +4,12 @@ use rand::Rng; // Assuming block.rs is in the same directory
 pub const CHUNK_WIDTH: usize = 16;
 pub const CHUNK_HEIGHT: usize = 32; // Reduced height for now
 pub const CHUNK_DEPTH: usize = 16;
+pub const MAX_LIGHT: u8 = 15;
 
 pub struct Chunk {
     pub coord: (i32, i32),        // Add world coordinates (x, z) for the chunk
     blocks: Vec<Vec<Vec<Block>>>, // Stored as [x][y][z]
+    light_levels: Vec<Vec<Vec<u8>>>, // Stored as [x][y][z]
 }
 
 impl Chunk {
@@ -15,9 +17,41 @@ impl Chunk {
         // Initialize with Air blocks
         let blocks =
             vec![vec![vec![Block::new(BlockType::Air); CHUNK_DEPTH]; CHUNK_HEIGHT]; CHUNK_WIDTH];
+        // Initialize light levels to 0
+        let light_levels =
+            vec![vec![vec![0u8; CHUNK_DEPTH]; CHUNK_HEIGHT]; CHUNK_WIDTH];
         Chunk {
             coord: (coord_x, coord_z),
             blocks,
+            light_levels,
+        }
+    }
+
+    pub fn calculate_initial_sunlight(&mut self) {
+        for x in 0..CHUNK_WIDTH {
+            for z in 0..CHUNK_DEPTH {
+                let mut light_penetration = MAX_LIGHT;
+                for y in (0..CHUNK_HEIGHT).rev() { // Iterate from top to bottom
+                    let block = &mut self.blocks[x][y][z];
+                    if light_penetration > 0 {
+                        if block.is_solid() {
+                             // Solid blocks stop light penetration for blocks below them in this column.
+                             // The current solid block still gets the current light_penetration value.
+                            self.light_levels[x][y][z] = light_penetration;
+                            light_penetration = 0; // Stop light for blocks below this one in this column
+                        } else if block.is_transparent() {
+                            // Transparent blocks (like leaves) get full light and reduce it slightly for below.
+                            self.light_levels[x][y][z] = light_penetration;
+                            // For now, leaves don't dim light, but this is where you could add it:
+                            // light_penetration = light_penetration.saturating_sub(1);
+                        } else { // Air block
+                            self.light_levels[x][y][z] = light_penetration;
+                        }
+                    } else {
+                        self.light_levels[x][y][z] = 0;
+                    }
+                }
+            }
         }
     }
 
@@ -42,7 +76,7 @@ impl Chunk {
 
         // --- TASK: Pass 2: Generate Trees ---
         // After the main terrain is set, we make a second pass to add features like trees.
-        let mut rng = rand::rng(); // Create a random number generator
+        let mut rng = rand::thread_rng(); // Create a random number generator
         const TREE_CHANCE: f64 = 0.02; // 2% chance to try and place a tree at any given spot
 
         for x in 2..(CHUNK_WIDTH - 2) {
@@ -51,13 +85,15 @@ impl Chunk {
                 // Check if the block at the surface level is grass
                 if self.blocks[x][surface_level][z].block_type == BlockType::Grass {
                     // Use the random number generator to decide if a tree should grow here
-                    if rng.random_bool(TREE_CHANCE) {
+                    if rng.gen_bool(TREE_CHANCE) { // Changed to rng.gen_bool
                         // The ground level for the tree trunk is one block above the grass.
                         self.place_tree(x, surface_level + 1, z);
                     }
                 }
             }
         }
+        // After all terrain and features are placed, calculate sunlight
+        self.calculate_initial_sunlight();
     }
 
     // TASK: Create a helper function to place a tree at a specific location.
@@ -125,6 +161,15 @@ impl Chunk {
         }
     }
 
+    // Helper to get a light level at a given coordinate
+    pub fn get_light_level(&self, x: usize, y: usize, z: usize) -> Option<u8> {
+        if x < CHUNK_WIDTH && y < CHUNK_HEIGHT && z < CHUNK_DEPTH {
+            Some(self.light_levels[x][y][z])
+        } else {
+            None
+        }
+    }
+
     // Helper to set a block at a given coordinate
     // Returns Result<(), &str> to indicate success or out-of-bounds error
     pub fn set_block(
@@ -136,9 +181,23 @@ impl Chunk {
     ) -> Result<(), &'static str> {
         if x < CHUNK_WIDTH && y < CHUNK_HEIGHT && z < CHUNK_DEPTH {
             self.blocks[x][y][z] = Block::new(block_type);
+            // NOTE: Light level is not set here directly.
+            // The light calculation pass will handle it.
+            // For dynamic updates, a call to recalculate light for this chunk
+            // (and potentially neighbors) would be needed after a block is set.
             Ok(())
         } else {
             Err("Coordinates out of chunk bounds")
+        }
+    }
+
+    // Helper to set a light level at a given coordinate
+    pub fn set_light_level(&mut self, x: usize, y: usize, z: usize, level: u8) -> Result<(), &'static str> {
+        if x < CHUNK_WIDTH && y < CHUNK_HEIGHT && z < CHUNK_DEPTH {
+            self.light_levels[x][y][z] = level.min(MAX_LIGHT); // Ensure light level doesn't exceed max
+            Ok(())
+        } else {
+            Err("Coordinates out of chunk bounds for light level")
         }
     }
 }

--- a/engine/src/chunk.rs
+++ b/engine/src/chunk.rs
@@ -55,6 +55,7 @@ impl Chunk {
         }
     }
 
+    #[allow(deprecated)] // Allow rand::thread_rng and rng.random_bool for now
     pub fn generate_terrain(&mut self) {
         let surface_level = CHUNK_HEIGHT / 2; // Grass will be at this Y level
 
@@ -85,7 +86,7 @@ impl Chunk {
                 // Check if the block at the surface level is grass
                 if self.blocks[x][surface_level][z].block_type == BlockType::Grass {
                     // Use the random number generator to decide if a tree should grow here
-                    if rng.gen_bool(TREE_CHANCE) { // Changed to rng.gen_bool
+                    if rng.random_bool(TREE_CHANCE) { // Changed to random_bool as per warning
                         // The ground level for the tree trunk is one block above the grass.
                         self.place_tree(x, surface_level + 1, z);
                     }

--- a/engine/src/cube_geometry.rs
+++ b/engine/src/cube_geometry.rs
@@ -8,21 +8,25 @@ const CUBE_VERTICES_DATA: &[Vertex] = &[
         position: [-0.5, -0.5, -0.5],
         color: [1.0, 0.0, 0.0],
         uv: [0.0, 0.0],
+        light_level: 1.0,
     }, // 0 (orig V0)
     Vertex {
         position: [-0.5, 0.5, -0.5],
         color: [1.0, 0.0, 0.0],
         uv: [0.0, 0.0],
+        light_level: 1.0,
     }, // 1 (orig V3)
     Vertex {
         position: [0.5, 0.5, -0.5],
         color: [1.0, 0.0, 0.0],
         uv: [0.0, 0.0],
+        light_level: 1.0,
     }, // 2 (orig V2)
     Vertex {
         position: [0.5, -0.5, -0.5],
         color: [1.0, 0.0, 0.0],
         uv: [0.0, 0.0],
+        light_level: 1.0,
     }, // 3 (orig V1)
     // Back face (Z = 0.5) - CCW from back (viewing towards -Z, normal 0,0,1)
     // Order: BL, BR, TR, TL (relative to its own view, e.g. V4,V5,V6,V7 is already this)
@@ -30,21 +34,25 @@ const CUBE_VERTICES_DATA: &[Vertex] = &[
         position: [-0.5, -0.5, 0.5],
         color: [0.0, 1.0, 0.0],
         uv: [0.0, 0.0],
+        light_level: 1.0,
     }, // 4 (orig V4)
     Vertex {
         position: [0.5, -0.5, 0.5],
         color: [0.0, 1.0, 0.0],
         uv: [0.0, 0.0],
+        light_level: 1.0,
     }, // 5 (orig V5)
     Vertex {
         position: [0.5, 0.5, 0.5],
         color: [0.0, 1.0, 0.0],
         uv: [0.0, 0.0],
+        light_level: 1.0,
     }, // 6 (orig V6)
     Vertex {
         position: [-0.5, 0.5, 0.5],
         color: [0.0, 1.0, 0.0],
         uv: [0.0, 0.0],
+        light_level: 1.0,
     }, // 7 (orig V7) - This order is correct
     // Right face (X = 0.5) - REORDERED FOR CCW from right (viewing towards -X, normal 1,0,0)
     // Order: BFR, TFR, TBR, BBR (Bottom-Front, Top-Front, Top-Back, Bottom-Back)
@@ -52,21 +60,25 @@ const CUBE_VERTICES_DATA: &[Vertex] = &[
         position: [0.5, -0.5, -0.5],
         color: [0.0, 0.0, 1.0],
         uv: [0.0, 0.0],
+        light_level: 1.0,
     }, // 8 (orig V8)
     Vertex {
         position: [0.5, 0.5, -0.5],
         color: [0.0, 0.0, 1.0],
         uv: [0.0, 0.0],
+        light_level: 1.0,
     }, // 9 (orig V11)
     Vertex {
         position: [0.5, 0.5, 0.5],
         color: [0.0, 0.0, 1.0],
         uv: [0.0, 0.0],
+        light_level: 1.0,
     }, // 10 (orig V10)
     Vertex {
         position: [0.5, -0.5, 0.5],
         color: [0.0, 0.0, 1.0],
         uv: [0.0, 0.0],
+        light_level: 1.0,
     }, // 11 (orig V9)
     // Left face (X = -0.5) - REORDERED FOR CCW from left (viewing towards +X, normal -1,0,0)
     // Order: BBL, TBL, TFL, BFL (Bottom-Back, Top-Back, Top-Front, Bottom-Front)
@@ -74,21 +86,25 @@ const CUBE_VERTICES_DATA: &[Vertex] = &[
         position: [-0.5, -0.5, 0.5],
         color: [1.0, 1.0, 0.0],
         uv: [0.0, 0.0],
+        light_level: 1.0,
     }, // 12 (orig V12)
     Vertex {
         position: [-0.5, 0.5, 0.5],
         color: [1.0, 1.0, 0.0],
         uv: [0.0, 0.0],
+        light_level: 1.0,
     }, // 13 (orig V15)
     Vertex {
         position: [-0.5, 0.5, -0.5],
         color: [1.0, 1.0, 0.0],
         uv: [0.0, 0.0],
+        light_level: 1.0,
     }, // 14 (orig V14)
     Vertex {
         position: [-0.5, -0.5, -0.5],
         color: [1.0, 1.0, 0.0],
         uv: [0.0, 0.0],
+        light_level: 1.0,
     }, // 15 (orig V13)
     // Top face (Y = 0.5) - REORDERED FOR CCW from above (viewing towards -Y, normal 0,1,0)
     // Order: Near-Left, Near-Right, Far-Right, Far-Left (relative to view from +Y)
@@ -96,21 +112,25 @@ const CUBE_VERTICES_DATA: &[Vertex] = &[
         position: [-0.5, 0.5, 0.5],
         color: [1.0, 0.0, 1.0],
         uv: [0.0, 0.0],
+        light_level: 1.0,
     }, // 16 (Original V19)
     Vertex {
         position: [0.5, 0.5, 0.5],
         color: [1.0, 0.0, 1.0],
         uv: [0.0, 0.0],
+        light_level: 1.0,
     }, // 17 (Original V18)
     Vertex {
         position: [0.5, 0.5, -0.5],
         color: [1.0, 0.0, 1.0],
         uv: [0.0, 0.0],
+        light_level: 1.0,
     }, // 18 (Original V17)
     Vertex {
         position: [-0.5, 0.5, -0.5],
         color: [1.0, 0.0, 1.0],
         uv: [0.0, 0.0],
+        light_level: 1.0,
     }, // 19 (Original V16)
     // Bottom face (Y = -0.5) - REORDERED FOR CCW from below (viewing towards +Y, normal 0,-1,0)
     // Order: Near-Left, Far-Left, Far-Right, Near-Right (relative to view from -Y)
@@ -118,21 +138,25 @@ const CUBE_VERTICES_DATA: &[Vertex] = &[
         position: [-0.5, -0.5, 0.5],
         color: [0.0, 1.0, 1.0],
         uv: [0.0, 0.0],
+        light_level: 1.0,
     }, // 20 (Original V20)
     Vertex {
         position: [-0.5, -0.5, -0.5],
         color: [0.0, 1.0, 1.0],
         uv: [0.0, 0.0],
+        light_level: 1.0,
     }, // 21 (Original V23)
     Vertex {
         position: [0.5, -0.5, -0.5],
         color: [0.0, 1.0, 1.0],
         uv: [0.0, 0.0],
+        light_level: 1.0,
     }, // 22 (Original V22)
     Vertex {
         position: [0.5, -0.5, 0.5],
         color: [0.0, 1.0, 1.0],
         uv: [0.0, 0.0],
+        light_level: 1.0,
     }, // 23 (Original V21)
 ];
 

--- a/engine/src/world.rs
+++ b/engine/src/world.rs
@@ -90,7 +90,13 @@ impl World {
 
         let chunk = self.get_or_create_chunk(chunk_x, chunk_z);
         match chunk.set_block(local_x, local_y, local_z, block_type) {
-            Ok(_) => Ok((chunk_x, chunk_z)),
+            Ok(_) => {
+                // After setting a block, recalculate sunlight for this chunk.
+                // This is a simple approach. A more advanced system would update
+                // light propagation starting from the modified block.
+                chunk.calculate_initial_sunlight();
+                Ok((chunk_x, chunk_z))
+            }
             Err(e) => Err(e), // Propagate error from chunk.set_block
         }
     }


### PR DESCRIPTION
Features:
- Added `light_level` to `Block` and `Vertex` structs.
- Implemented initial sunlight calculation in `Chunk`, where sky-exposed blocks receive full light (15) and light diminishes to 0 under solid blocks.
- Updated chunk meshing to include `light_level` in vertex data.
- Modified shader to use `light_level` to modulate fragment brightness, creating darker areas in caves or under overhangs.
- Ensured world updates recalculate sunlight for affected chunks after block changes (simple recalculation for now).

Fixes:
- Corrected `Vertex` initializers in `cube_geometry.rs` to include the new `light_level` field.