### PR TITLE
Fix segmentation fault on exit

### DIFF
--- a/engine/src/main.rs
+++ b/engine/src/main.rs
@@ -206,6 +206,7 @@ impl ApplicationHandler for App {
 
     fn exiting(&mut self, _event_loop: &ActiveEventLoop) {
         println!("ApplicationHandler: Event loop is exiting. Cleaning up.");
+        self.state = None;
     }
 }
 


### PR DESCRIPTION
The application was crashing on exit due to improper resource cleanup. This change ensures that the `State` object is properly dropped in the `exiting` function of the `ApplicationHandler`, which resolves the segmentation fault.