### PR TITLE
Correct Voxel Face Lighting

### DIFF
--- a/engine/src/main.rs
+++ b/engine/src/main.rs
@@ -690,18 +690,21 @@ impl State {
                             let neighbor_world_bz =
                                 chunk_world_origin_z as i32 + lz as i32 + offset.2;
 
-                            let mut is_face_visible = true;
+                            let mut face_sky_light = 0;
+                            let mut is_face_visible = false;
                             if neighbor_world_by >= 0 && neighbor_world_by < CHUNK_HEIGHT as i32 {
                                 if let Some(neighbor_block) = self.world.get_block_at_world(
                                     neighbor_world_bx as f32,
                                     neighbor_world_by as f32,
                                     neighbor_world_bz as f32,
                                 ) {
-                                    if neighbor_block.is_solid() && !neighbor_block.is_transparent()
-                                    {
-                                        is_face_visible = false;
+                                    if neighbor_block.is_transparent() {
+                                        is_face_visible = true;
+                                        face_sky_light = neighbor_block.sky_light;
                                     }
                                 }
+                            } else {
+                                is_face_visible = true;
                             }
 
                             if is_face_visible {
@@ -767,7 +770,7 @@ impl State {
                                             color: current_vertex_color,
                                             uv: selected_face_uvs[i],
                                             tree_id: 0,
-                                            sky_light: block.sky_light as u32,
+                                            sky_light: face_sky_light as u32,
                                         });
                                     }
                                     for local_idx in local_indices {
@@ -810,7 +813,8 @@ impl State {
                 (CubeFace::Bottom, (0, -1, 0)),
             ];
             for (face_type, _offset) in face_definitions.iter() {
-                let mut is_face_visible_for_transparent = true;
+                let mut face_sky_light = 0;
+                let mut is_face_visible_for_transparent = false;
                 let neighbor_check_offset = match face_type {
                     CubeFace::Front => (0, 0, -1),
                     CubeFace::Back => (0, 0, 1),
@@ -836,12 +840,15 @@ impl State {
                         neighbor_world_by_transparent as f32,
                         neighbor_world_bz_transparent as f32,
                     ) {
-                        if !neighbor_block_transparent.is_transparent()
-                            || neighbor_block_transparent.block_type == block.block_type
+                        if neighbor_block_transparent.is_transparent()
+                            && neighbor_block_transparent.block_type != block.block_type
                         {
-                            is_face_visible_for_transparent = false;
+                            is_face_visible_for_transparent = true;
+                            face_sky_light = neighbor_block_transparent.sky_light;
                         }
                     }
+                } else {
+                    is_face_visible_for_transparent = true;
                 }
 
                 if !is_face_visible_for_transparent {
@@ -899,7 +906,7 @@ impl State {
                         color: current_vertex_color,
                         uv: selected_face_uvs[i],
                         tree_id: current_tree_id,
-                        sky_light: block.sky_light as u32,
+                        sky_light: face_sky_light as u32,
                     });
                 }
                 for local_idx in local_indices {

--- a/engine/src/shader.wgsl
+++ b/engine/src/shader.wgsl
@@ -66,7 +66,11 @@ fn fs_main(in: FragmentInput) -> @location(0) vec4<f32> {
     if (sampled_color.a < 0.1) {
         discard;
     }
-    let light_intensity = (f32(in.sky_light) / 15.0) * 0.4 + 0.1;
+    let light_levels = array<f32, 16>(
+        0.05, 0.1133, 0.1767, 0.24, 0.3033, 0.3667, 0.43, 0.4933,
+        0.5567, 0.62, 0.6833, 0.7467, 0.81, 0.8733, 0.9367, 1.0
+    );
+    let light_intensity = light_levels[in.sky_light];
     var final_color = sampled_color.rgb * light_intensity;
 
 

--- a/engine/src/shader.wgsl
+++ b/engine/src/shader.wgsl
@@ -66,7 +66,7 @@ fn fs_main(in: FragmentInput) -> @location(0) vec4<f32> {
     if (sampled_color.a < 0.1) {
         discard;
     }
-    let light_intensity = f32(in.sky_light) / 15.0;
+    let light_intensity = (f32(in.sky_light) / 15.0) * 0.8 + 0.2;
     var final_color = sampled_color.rgb * light_intensity;
 
 

--- a/engine/src/shader.wgsl
+++ b/engine/src/shader.wgsl
@@ -66,7 +66,7 @@ fn fs_main(in: FragmentInput) -> @location(0) vec4<f32> {
     if (sampled_color.a < 0.1) {
         discard;
     }
-    let light_intensity = (f32(in.sky_light) / 15.0) * 0.8 + 0.2;
+    let light_intensity = (f32(in.sky_light) / 15.0) * 0.4 + 0.1;
     var final_color = sampled_color.rgb * light_intensity;
 
 

--- a/engine/src/shader.wgsl
+++ b/engine/src/shader.wgsl
@@ -66,11 +66,8 @@ fn fs_main(in: FragmentInput) -> @location(0) vec4<f32> {
     if (sampled_color.a < 0.1) {
         discard;
     }
-    let light_levels = array<f32, 16>(
-        0.05, 0.1133, 0.1767, 0.24, 0.3033, 0.3667, 0.43, 0.4933,
-        0.5567, 0.62, 0.6833, 0.7467, 0.81, 0.8733, 0.9367, 1.0
-    );
-    let light_intensity = light_levels[in.sky_light];
+    let normalized_light = f32(in.sky_light) / 15.0;
+    let light_intensity = 0.05 + pow(normalized_light, 2.0) * 0.95;
     var final_color = sampled_color.rgb * light_intensity;
 
 

--- a/engine/src/shader.wgsl
+++ b/engine/src/shader.wgsl
@@ -47,16 +47,20 @@ struct FragmentInput {
     @location(3) @interpolate(flat) sky_light: u32,
 }
 
-// Simple hash function to generate a color from a u32
-// Source: https://www.shadertoy.com/view/XlGcRh (simplified)
-fn hash_to_color(id: u32) -> vec3<f32> {
-    var id_float = f32(id);
-    let r = fract(sin(id_float * 12.9898) * 43758.5453);
-    let g = fract(sin(id_float * 78.233) * 43758.5453);
-    let b = fract(sin(id_float * 33.731) * 43758.5453);
-    return vec3<f32>(r, g, b);
-}
+// Calculates a point on a 1D cubic Bezier curve.
+// t: The input progress (0.0 to 1.0)
+// p0, p3: The start and end values of the curve
+// p1, p2: The control point "handles" that shape the curve
+fn cubic_bezier(p0: f32, p1: f32, p2: f32, p3: f32, t: f32) -> f32 {
+    let t_inv = 1.0 - t;
+    let t_inv_sq = t_inv * t_inv;
+    let t_sq = t * t;
 
+    return (t_inv_sq * t_inv * p0) +
+           (3.0 * t_inv_sq * t * p1) +
+           (3.0 * t_inv * t_sq * p2) +
+           (t_sq * t * p3);
+}
 
 @fragment
 fn fs_main(in: FragmentInput) -> @location(0) vec4<f32> {
@@ -66,10 +70,17 @@ fn fs_main(in: FragmentInput) -> @location(0) vec4<f32> {
     if (sampled_color.a < 0.1) {
         discard;
     }
-    let normalized_light = f32(in.sky_light) / 15.0;
-    let light_intensity = 0.05 + pow(normalized_light, 2.0) * 0.95;
-    var final_color = sampled_color.rgb * light_intensity;
 
+    let normalized_light = f32(in.sky_light) / 15.0;
+
+    // 1. Calculate the curve's output (from 0.0 to 1.0) using control points
+    //    that create a sharp "ease-in" effect.
+    let bezier_y = cubic_bezier(0.0, 0.0, 0.1, 1.0, normalized_light);
+
+    // 2. Remap the curve's output to your desired brightness range [0.05, 1.0].
+    let light_intensity = 0.05 + bezier_y * 0.95;
+
+    var final_color = sampled_color.rgb * light_intensity;
 
     // Sentinel color for Grass Top, set in main.rs: [0.1, 0.9, 0.1]
     let grass_top_sentinel = vec3<f32>(0.1, 0.9, 0.1);
@@ -94,5 +105,4 @@ fn fs_main(in: FragmentInput) -> @location(0) vec4<f32> {
     }
 
     return vec4<f32>(final_color.rgb, 1.0); // Return full alpha
-
 }


### PR DESCRIPTION
- I modified the chunk mesh generation logic to correctly light block faces.
- A face's brightness is now determined by the light level of the adjacent air block it is exposed to, not the light level of the solid block itself.