### PR TITLE
feat: Add inventory UI

### DIFF
--- a/engine/src/crosshair_shader.wgsl
+++ b/engine/src/crosshair_shader.wgsl
@@ -1,0 +1,30 @@
+// engine/src/crosshair_shader.wgsl
+
+// Vertex shader
+struct VertexInput {
+    @location(0) position: vec2<f32>,
+};
+
+struct VertexOutput {
+    @builtin(position) clip_position: vec4<f32>,
+};
+
+struct ProjectionUniform {
+    projection_matrix: mat4x4<f32>,
+};
+
+@group(0) @binding(0)
+var<uniform> u_projection: ProjectionUniform;
+
+@vertex
+fn vs_main(model: VertexInput) -> VertexOutput {
+    var out: VertexOutput;
+    out.clip_position = u_projection.projection_matrix * vec4<f32>(model.position, 0.0, 1.0);
+    return out;
+}
+
+// Fragment shader
+@fragment
+fn fs_main() -> @location(0) vec4<f32> {
+    return vec4<f32>(1.0, 1.0, 1.0, 1.0); // White
+}

--- a/engine/src/main.rs
+++ b/engine/src/main.rs
@@ -1355,9 +1355,10 @@ impl State {
                 timestamp_writes: None,
                 occlusion_query_set: None,
             });
-            self.crosshair.draw(&mut ui_render_pass);
             if self.inventory_open {
                 self.inventory.draw(&mut ui_render_pass);
+            } else {
+                self.crosshair.draw(&mut ui_render_pass);
             }
         }
         {

--- a/engine/src/main.rs
+++ b/engine/src/main.rs
@@ -98,7 +98,11 @@ impl App {
                 }
                 if mouse_element_state == ElementState::Pressed {
                     if !self.mouse_grabbed {
-                        self.set_mouse_grab(true);
+                        if let Some(state) = self.state.as_ref() {
+                            if !state.inventory_open {
+                                self.set_mouse_grab(true);
+                            }
+                        }
                     }
                 }
             }

--- a/engine/src/main.rs
+++ b/engine/src/main.rs
@@ -64,17 +64,30 @@ impl App {
             WindowEvent::KeyboardInput {
                 event: ref key_event,
                 ..
-            } if key_event.physical_key == PhysicalKey::Code(KeyCode::Escape)
-                && key_event.state == ElementState::Pressed =>
-            {
-                if self.mouse_grabbed {
-                    self.set_mouse_grab(false);
-                    event_consumed_by_grab_logic = true;
-                } else {
-                    active_loop.exit();
-                    return;
+            } if key_event.state == ElementState::Pressed => match key_event.physical_key {
+                PhysicalKey::Code(KeyCode::Escape) => {
+                    if self.mouse_grabbed {
+                        self.set_mouse_grab(false);
+                        if let Some(state) = self.state.as_mut() {
+                            state.inventory_open = false;
+                        }
+                        event_consumed_by_grab_logic = true;
+                    } else {
+                        active_loop.exit();
+                        return;
+                    }
                 }
-            }
+                PhysicalKey::Code(KeyCode::KeyE) => {
+                    let mut inventory_open = false;
+                    if let Some(state) = self.state.as_mut() {
+                        state.inventory_open = !state.inventory_open;
+                        inventory_open = state.inventory_open;
+                        event_consumed_by_grab_logic = true;
+                    }
+                    self.set_mouse_grab(!inventory_open);
+                }
+                _ => {}
+            },
             WindowEvent::MouseInput {
                 button,
                 state: mouse_element_state,
@@ -307,6 +320,8 @@ struct State {
     depth_texture_view: wgpu::TextureView,
     debug_overlay: DebugOverlay,
     crosshair: ui::crosshair::Crosshair,
+    inventory: ui::inventory::Inventory,
+    inventory_open: bool,
     wireframe_renderer: WireframeRenderer,
     selected_block: Option<(IVec3, BlockFace)>,
     diffuse_bind_group: wgpu::BindGroup,
@@ -596,6 +611,7 @@ impl State {
 
         let debug_overlay = DebugOverlay::new(&device, &config);
         let crosshair = ui::crosshair::Crosshair::new(&device, &config);
+        let inventory = ui::inventory::Inventory::new(&device, &config);
         let wireframe_renderer =
             WireframeRenderer::new(&device, &config, &camera_bind_group_layout);
 
@@ -620,6 +636,8 @@ impl State {
             wireframe_renderer,
             selected_block: None,
             crosshair,
+            inventory,
+            inventory_open: false,
             diffuse_bind_group,
             input_state: input::InputState::new(),
         }
@@ -1319,22 +1337,24 @@ impl State {
             }
         }
         {
-            let mut crosshair_render_pass =
-                encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
-                    label: Some("Crosshair Render Pass"),
-                    color_attachments: &[Some(wgpu::RenderPassColorAttachment {
-                        view: &view,
-                        resolve_target: None,
-                        ops: wgpu::Operations {
-                            load: wgpu::LoadOp::Load,
-                            store: wgpu::StoreOp::Store,
-                        },
-                    })],
-                    depth_stencil_attachment: None,
-                    timestamp_writes: None,
-                    occlusion_query_set: None,
-                });
-            self.crosshair.draw(&mut crosshair_render_pass);
+            let mut ui_render_pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                label: Some("UI Render Pass"),
+                color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                    view: &view,
+                    resolve_target: None,
+                    ops: wgpu::Operations {
+                        load: wgpu::LoadOp::Load,
+                        store: wgpu::StoreOp::Store,
+                    },
+                })],
+                depth_stencil_attachment: None,
+                timestamp_writes: None,
+                occlusion_query_set: None,
+            });
+            self.crosshair.draw(&mut ui_render_pass);
+            if self.inventory_open {
+                self.inventory.draw(&mut ui_render_pass);
+            }
         }
         {
             let mut debug_text_render_pass =

--- a/engine/src/ui/crosshair.rs
+++ b/engine/src/ui/crosshair.rs
@@ -112,8 +112,8 @@ impl Crosshair {
         });
 
         let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
-            label: Some("UI Shader"),
-            source: wgpu::ShaderSource::Wgsl(include_str!("../ui_shader.wgsl").into()),
+            label: Some("Crosshair Shader"),
+            source: wgpu::ShaderSource::Wgsl(include_str!("../crosshair_shader.wgsl").into()),
         });
 
         let render_pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {

--- a/engine/src/ui/inventory.rs
+++ b/engine/src/ui/inventory.rs
@@ -49,6 +49,21 @@ impl Inventory {
 
         let mut vertices: Vec<InventoryVertex> = Vec::new();
 
+        // Background
+        let bg_width = (GRID_COLS as f32 * TOTAL_SLOT_SIZE) + SLOT_MARGIN;
+        let bg_height = ((GRID_ROWS + ACTIVE_GRID_ROWS) as f32 * TOTAL_SLOT_SIZE) + SLOT_MARGIN * 4.0;
+        let bg_start_x = -bg_width / 2.0;
+        let bg_start_y = -bg_height / 2.0;
+
+        vertices.push(InventoryVertex { position: [bg_start_x, bg_start_y] });
+        vertices.push(InventoryVertex { position: [bg_start_x + bg_width, bg_start_y] });
+        vertices.push(InventoryVertex { position: [bg_start_x, bg_start_y + bg_height] });
+
+        vertices.push(InventoryVertex { position: [bg_start_x + bg_width, bg_start_y] });
+        vertices.push(InventoryVertex { position: [bg_start_x + bg_width, bg_start_y + bg_height] });
+        vertices.push(InventoryVertex { position: [bg_start_x, bg_start_y + bg_height] });
+
+
         // Main inventory grid (3x9)
         let grid_width = GRID_COLS as f32 * TOTAL_SLOT_SIZE - SLOT_MARGIN;
         let grid_height = GRID_ROWS as f32 * TOTAL_SLOT_SIZE - SLOT_MARGIN;
@@ -74,7 +89,7 @@ impl Inventory {
         // Active items grid (1x9)
         let active_grid_width = ACTIVE_GRID_COLS as f32 * TOTAL_SLOT_SIZE - SLOT_MARGIN;
         let active_start_x = -active_grid_width / 2.0;
-        let active_start_y = start_y - TOTAL_SLOT_SIZE - 20.0; // Position below the main grid
+        let active_start_y = start_y + grid_height + TOTAL_SLOT_SIZE + 20.0; // Position above the main grid
 
         for row in 0..ACTIVE_GRID_ROWS {
             for col in 0..ACTIVE_GRID_COLS {

--- a/engine/src/ui/inventory.rs
+++ b/engine/src/ui/inventory.rs
@@ -94,7 +94,7 @@ impl Inventory {
         // Active items grid (1x9)
         let active_grid_width = ACTIVE_GRID_COLS as f32 * TOTAL_SLOT_SIZE - SLOT_MARGIN;
         let active_start_x = -active_grid_width / 2.0;
-        let active_start_y = start_y + grid_height + TOTAL_SLOT_SIZE; // Position above the main grid
+        let active_start_y = start_y + grid_height + TOTAL_SLOT_SIZE + 10.0; // Position above the main grid
         let active_slot_color = [0.4, 0.4, 0.4, 0.8];
 
         for row in 0..ACTIVE_GRID_ROWS {

--- a/engine/src/ui/inventory.rs
+++ b/engine/src/ui/inventory.rs
@@ -32,9 +32,7 @@ pub struct Inventory {
     pub vertex_buffer: wgpu::Buffer,
     pub num_vertices: u32,
     pub render_pipeline: wgpu::RenderPipeline,
-    projection_matrix: glam::Mat4,
     pub projection_buffer: wgpu::Buffer,
-    projection_bind_group_layout: wgpu::BindGroupLayout,
     pub projection_bind_group: wgpu::BindGroup,
 }
 
@@ -210,28 +208,8 @@ impl Inventory {
             vertex_buffer,
             num_vertices,
             render_pipeline,
-            projection_matrix,
             projection_buffer,
-            projection_bind_group_layout,
             projection_bind_group,
-        }
-    }
-
-    pub fn resize(&mut self, new_size: winit::dpi::PhysicalSize<u32>, queue: &wgpu::Queue) {
-        if new_size.width > 0 && new_size.height > 0 {
-            self.projection_matrix = glam::Mat4::orthographic_rh(
-                -(new_size.width as f32) / 2.0,
-                new_size.width as f32 / 2.0,
-                new_size.height as f32 / 2.0,
-                -(new_size.height as f32) / 2.0,
-                -1.0,
-                1.0,
-            );
-            queue.write_buffer(
-                &self.projection_buffer,
-                0,
-                bytemuck::cast_slice(self.projection_matrix.as_ref()),
-            );
         }
     }
 

--- a/engine/src/ui/inventory.rs
+++ b/engine/src/ui/inventory.rs
@@ -32,7 +32,6 @@ pub struct Inventory {
     pub vertex_buffer: wgpu::Buffer,
     pub num_vertices: u32,
     pub render_pipeline: wgpu::RenderPipeline,
-    pub projection_buffer: wgpu::Buffer,
     pub projection_bind_group: wgpu::BindGroup,
 }
 
@@ -95,7 +94,7 @@ impl Inventory {
         // Active items grid (1x9)
         let active_grid_width = ACTIVE_GRID_COLS as f32 * TOTAL_SLOT_SIZE - SLOT_MARGIN;
         let active_start_x = -active_grid_width / 2.0;
-        let active_start_y = start_y + grid_height + TOTAL_SLOT_SIZE + 20.0; // Position above the main grid
+        let active_start_y = start_y + grid_height + TOTAL_SLOT_SIZE; // Position above the main grid
         let active_slot_color = [0.4, 0.4, 0.4, 0.8];
 
         for row in 0..ACTIVE_GRID_ROWS {
@@ -208,7 +207,6 @@ impl Inventory {
             vertex_buffer,
             num_vertices,
             render_pipeline,
-            projection_buffer,
             projection_bind_group,
         }
     }

--- a/engine/src/ui/inventory.rs
+++ b/engine/src/ui/inventory.rs
@@ -50,19 +50,37 @@ impl Inventory {
 
         // Background
         let bg_width = (GRID_COLS as f32 * TOTAL_SLOT_SIZE) + SLOT_MARGIN * 2.0;
-        let bg_height = (GRID_ROWS as f32 * TOTAL_SLOT_SIZE) + SLOT_MARGIN * 2.0;
+        let bg_height =
+            (GRID_ROWS as f32 * TOTAL_SLOT_SIZE) + SLOT_MARGIN * 2.0 + SLOT_MARGIN * 2.0;
         let bg_start_x = -bg_width / 2.0;
-        let bg_start_y = -bg_height / 2.0;
+        let bg_start_y = -bg_height / 2.0 + SLOT_MARGIN;
         let bg_color = [0.1, 0.1, 0.1, 0.8];
 
-        vertices.push(InventoryVertex { position: [bg_start_x, bg_start_y], color: bg_color });
-        vertices.push(InventoryVertex { position: [bg_start_x + bg_width, bg_start_y], color: bg_color });
-        vertices.push(InventoryVertex { position: [bg_start_x, bg_start_y + bg_height], color: bg_color });
+        vertices.push(InventoryVertex {
+            position: [bg_start_x, bg_start_y],
+            color: bg_color,
+        });
+        vertices.push(InventoryVertex {
+            position: [bg_start_x + bg_width, bg_start_y],
+            color: bg_color,
+        });
+        vertices.push(InventoryVertex {
+            position: [bg_start_x, bg_start_y + bg_height],
+            color: bg_color,
+        });
 
-        vertices.push(InventoryVertex { position: [bg_start_x + bg_width, bg_start_y], color: bg_color });
-        vertices.push(InventoryVertex { position: [bg_start_x + bg_width, bg_start_y + bg_height], color: bg_color });
-        vertices.push(InventoryVertex { position: [bg_start_x, bg_start_y + bg_height], color: bg_color });
-
+        vertices.push(InventoryVertex {
+            position: [bg_start_x + bg_width, bg_start_y],
+            color: bg_color,
+        });
+        vertices.push(InventoryVertex {
+            position: [bg_start_x + bg_width, bg_start_y + bg_height],
+            color: bg_color,
+        });
+        vertices.push(InventoryVertex {
+            position: [bg_start_x, bg_start_y + bg_height],
+            color: bg_color,
+        });
 
         // Main inventory grid (4x9)
         let grid_width = GRID_COLS as f32 * TOTAL_SLOT_SIZE - SLOT_MARGIN;
@@ -74,16 +92,37 @@ impl Inventory {
         for row in 0..GRID_ROWS {
             for col in 0..GRID_COLS {
                 let x = start_x + col as f32 * TOTAL_SLOT_SIZE;
-                let y = start_y + row as f32 * TOTAL_SLOT_SIZE;
+                let mut y = start_y + row as f32 * TOTAL_SLOT_SIZE;
+                if row > 2 {
+                    y += SLOT_MARGIN * 2.0;
+                }
 
                 // Create a quad for each slot
-                vertices.push(InventoryVertex { position: [x, y], color: slot_color });
-                vertices.push(InventoryVertex { position: [x + SLOT_SIZE, y], color: slot_color });
-                vertices.push(InventoryVertex { position: [x, y + SLOT_SIZE], color: slot_color });
+                vertices.push(InventoryVertex {
+                    position: [x, y],
+                    color: slot_color,
+                });
+                vertices.push(InventoryVertex {
+                    position: [x + SLOT_SIZE, y],
+                    color: slot_color,
+                });
+                vertices.push(InventoryVertex {
+                    position: [x, y + SLOT_SIZE],
+                    color: slot_color,
+                });
 
-                vertices.push(InventoryVertex { position: [x + SLOT_SIZE, y], color: slot_color });
-                vertices.push(InventoryVertex { position: [x + SLOT_SIZE, y + SLOT_SIZE], color: slot_color });
-                vertices.push(InventoryVertex { position: [x, y + SLOT_SIZE], color: slot_color });
+                vertices.push(InventoryVertex {
+                    position: [x + SLOT_SIZE, y],
+                    color: slot_color,
+                });
+                vertices.push(InventoryVertex {
+                    position: [x + SLOT_SIZE, y + SLOT_SIZE],
+                    color: slot_color,
+                });
+                vertices.push(InventoryVertex {
+                    position: [x, y + SLOT_SIZE],
+                    color: slot_color,
+                });
             }
         }
 
@@ -109,19 +148,20 @@ impl Inventory {
             usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
         });
 
-        let projection_bind_group_layout = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
-            entries: &[wgpu::BindGroupLayoutEntry {
-                binding: 0,
-                visibility: wgpu::ShaderStages::VERTEX,
-                ty: wgpu::BindingType::Buffer {
-                    ty: wgpu::BufferBindingType::Uniform,
-                    has_dynamic_offset: false,
-                    min_binding_size: None,
-                },
-                count: None,
-            }],
-            label: Some("inventory_projection_bind_group_layout"),
-        });
+        let projection_bind_group_layout =
+            device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+                entries: &[wgpu::BindGroupLayoutEntry {
+                    binding: 0,
+                    visibility: wgpu::ShaderStages::VERTEX,
+                    ty: wgpu::BindingType::Buffer {
+                        ty: wgpu::BufferBindingType::Uniform,
+                        has_dynamic_offset: false,
+                        min_binding_size: None,
+                    },
+                    count: None,
+                }],
+                label: Some("inventory_projection_bind_group_layout"),
+            });
 
         let projection_bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
             layout: &projection_bind_group_layout,
@@ -137,11 +177,12 @@ impl Inventory {
             source: wgpu::ShaderSource::Wgsl(include_str!("../ui_shader.wgsl").into()),
         });
 
-        let render_pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
-            label: Some("Inventory Render Pipeline Layout"),
-            bind_group_layouts: &[&projection_bind_group_layout],
-            push_constant_ranges: &[],
-        });
+        let render_pipeline_layout =
+            device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+                label: Some("Inventory Render Pipeline Layout"),
+                bind_group_layouts: &[&projection_bind_group_layout],
+                push_constant_ranges: &[],
+            });
 
         let render_pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
             label: Some("Inventory Render Pipeline"),

--- a/engine/src/ui/inventory.rs
+++ b/engine/src/ui/inventory.rs
@@ -44,19 +44,15 @@ impl Inventory {
         const TOTAL_SLOT_SIZE: f32 = SLOT_SIZE + SLOT_MARGIN;
 
         const GRID_COLS: i32 = 9;
-        const GRID_ROWS: i32 = 3;
-
-        const ACTIVE_GRID_COLS: i32 = 9;
-        const ACTIVE_GRID_ROWS: i32 = 1;
-
+        const GRID_ROWS: i32 = 4;
 
         let mut vertices: Vec<InventoryVertex> = Vec::new();
 
         // Background
         let bg_width = (GRID_COLS as f32 * TOTAL_SLOT_SIZE) + SLOT_MARGIN * 2.0;
-        let bg_height = ((GRID_ROWS + ACTIVE_GRID_ROWS) as f32 * TOTAL_SLOT_SIZE) + SLOT_MARGIN * 5.0;
+        let bg_height = (GRID_ROWS as f32 * TOTAL_SLOT_SIZE) + SLOT_MARGIN * 2.0;
         let bg_start_x = -bg_width / 2.0;
-        let bg_start_y = -bg_height / 2.0 + 25.0;
+        let bg_start_y = -bg_height / 2.0;
         let bg_color = [0.1, 0.1, 0.1, 0.8];
 
         vertices.push(InventoryVertex { position: [bg_start_x, bg_start_y], color: bg_color });
@@ -68,7 +64,7 @@ impl Inventory {
         vertices.push(InventoryVertex { position: [bg_start_x, bg_start_y + bg_height], color: bg_color });
 
 
-        // Main inventory grid (3x9)
+        // Main inventory grid (4x9)
         let grid_width = GRID_COLS as f32 * TOTAL_SLOT_SIZE - SLOT_MARGIN;
         let grid_height = GRID_ROWS as f32 * TOTAL_SLOT_SIZE - SLOT_MARGIN;
         let start_x = -grid_width / 2.0;
@@ -88,28 +84,6 @@ impl Inventory {
                 vertices.push(InventoryVertex { position: [x + SLOT_SIZE, y], color: slot_color });
                 vertices.push(InventoryVertex { position: [x + SLOT_SIZE, y + SLOT_SIZE], color: slot_color });
                 vertices.push(InventoryVertex { position: [x, y + SLOT_SIZE], color: slot_color });
-            }
-        }
-
-        // Active items grid (1x9)
-        let active_grid_width = ACTIVE_GRID_COLS as f32 * TOTAL_SLOT_SIZE - SLOT_MARGIN;
-        let active_start_x = -active_grid_width / 2.0;
-        let active_start_y = start_y + grid_height + TOTAL_SLOT_SIZE + 10.0; // Position above the main grid
-        let active_slot_color = [0.4, 0.4, 0.4, 0.8];
-
-        for row in 0..ACTIVE_GRID_ROWS {
-            for col in 0..ACTIVE_GRID_COLS {
-                let x = active_start_x + col as f32 * TOTAL_SLOT_SIZE;
-                let y = active_start_y + row as f32 * TOTAL_SLOT_SIZE;
-
-                // Create a quad for each slot
-                vertices.push(InventoryVertex { position: [x, y], color: active_slot_color });
-                vertices.push(InventoryVertex { position: [x + SLOT_SIZE, y], color: active_slot_color });
-                vertices.push(InventoryVertex { position: [x, y + SLOT_SIZE], color: active_slot_color });
-
-                vertices.push(InventoryVertex { position: [x + SLOT_SIZE, y], color: active_slot_color });
-                vertices.push(InventoryVertex { position: [x + SLOT_SIZE, y + SLOT_SIZE], color: active_slot_color });
-                vertices.push(InventoryVertex { position: [x, y + SLOT_SIZE], color: active_slot_color });
             }
         }
 

--- a/engine/src/ui/mod.rs
+++ b/engine/src/ui/mod.rs
@@ -1,2 +1,3 @@
 // engine/src/ui/mod.rs
 pub mod crosshair;
+pub mod inventory;

--- a/engine/src/ui_shader.wgsl
+++ b/engine/src/ui_shader.wgsl
@@ -3,10 +3,12 @@
 // Vertex shader
 struct VertexInput {
     @location(0) position: vec2<f32>,
+    @location(1) color: vec4<f32>,
 };
 
 struct VertexOutput {
     @builtin(position) clip_position: vec4<f32>,
+    @location(0) color: vec4<f32>,
 };
 
 struct ProjectionUniform {
@@ -20,11 +22,12 @@ var<uniform> u_projection: ProjectionUniform;
 fn vs_main(model: VertexInput) -> VertexOutput {
     var out: VertexOutput;
     out.clip_position = u_projection.projection_matrix * vec4<f32>(model.position, 0.0, 1.0);
+    out.color = model.color;
     return out;
 }
 
 // Fragment shader
 @fragment
-fn fs_main() -> @location(0) vec4<f32> {
-    return vec4<f32>(0.9, 0.9, 0.9, 0.75); // Semi-transparent light grey
+fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
+    return in.color;
 }


### PR DESCRIPTION
This commit adds the basic UI for the inventory. It consists of a 3x9 grid for general items and a 1x9 grid for active items.

The inventory can be toggled by pressing the 'E' key. When the inventory is open, the mouse cursor is released to allow for interaction with the UI.