### PR TITLE
feat: Generate texture atlas at build time

### DIFF
--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -3,6 +3,9 @@ name = "engine"
 version = "0.1.0"
 edition = "2024"
 
+[build-dependencies]
+image = "0.25.6"
+
 [dependencies]
 bytemuck = "1.23.1"
 env_logger = "0.11.8"

--- a/engine/build.rs
+++ b/engine/build.rs
@@ -1,0 +1,43 @@
+use image::{GenericImage, RgbaImage};
+use std::env;
+use std::path::Path;
+
+fn main() {
+    let out_dir = env::var("OUT_DIR").unwrap();
+    let dest_path = Path::new(&out_dir).join("terrain_atlas.png");
+    let textures_dir = Path::new("assets/textures/block");
+
+    let texture_files = [
+        "grass_block_top.png",
+        "grass_block_side.png",
+        "dirt.png",
+        "bedrock.png",
+        "oak_log.png",
+        "oak_log_top.png",
+        "oak_leaves.png",
+    ];
+
+    let mut images = Vec::new();
+    for file_name in &texture_files {
+        let path = textures_dir.join(file_name);
+        images.push(image::open(&path).unwrap());
+    }
+
+    // All textures are 16x16, so we can create a 3x3 atlas
+    let atlas_width = 16 * 3;
+    let atlas_height = 16 * 3;
+    let mut atlas = RgbaImage::new(atlas_width, atlas_height);
+
+    for (i, img) in images.iter().enumerate() {
+        let col = (i % 3) as u32;
+        let row = (i / 3) as u32;
+        atlas
+            .copy_from(img, col * 16, row * 16)
+            .unwrap();
+    }
+
+    atlas.save(&dest_path).unwrap();
+
+    println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo:rerun-if-changed=assets/textures/block/");
+}

--- a/engine/src/block.rs
+++ b/engine/src/block.rs
@@ -61,26 +61,26 @@ impl Block {
     // Returns atlas indices (column, row) for each face: [Front, Back, Right, Left, Top, Bottom]
     pub fn get_texture_atlas_indices(&self) -> [[f32; 2]; 6] {
         match self.block_type {
-            BlockType::Dirt => [[2.0, 0.0]; 6], // Dirt texture at (2,0) in terrain.png
+            BlockType::Dirt => [[2.0, 0.0]; 6], // dirt.png
             BlockType::Grass => [
-                [3.0, 0.0], // Front (Grass Side)
-                [3.0, 0.0], // Back (Grass Side)
-                [3.0, 0.0], // Right (Grass Side)
-                [3.0, 0.0], // Left (Grass Side)
-                [0.0, 0.0], // Top (Grass Top)
-                [2.0, 0.0], // Bottom (Dirt)
+                [1.0, 0.0], // Front (grass_block_side.png)
+                [1.0, 0.0], // Back (grass_block_side.png)
+                [1.0, 0.0], // Right (grass_block_side.png)
+                [1.0, 0.0], // Left (grass_block_side.png)
+                [0.0, 0.0], // Top (grass_block_top.png)
+                [2.0, 0.0], // Bottom (dirt.png)
             ],
-            BlockType::Bedrock => [[1.0, 1.0]; 6], // Bedrock at (1,1)
+            BlockType::Bedrock => [[0.0, 1.0]; 6], // bedrock.png
             BlockType::Air => [[15.0, 15.0]; 6],   // Default/error texture (far corner of atlas)
             BlockType::OakLog => [
-                [4.0, 1.0],
-                [4.0, 1.0],
-                [4.0, 1.0],
-                [4.0, 1.0],
-                [5.0, 1.0],
-                [5.0, 1.0],
+                [1.0, 1.0], // Side (oak_log.png)
+                [1.0, 1.0], // Side (oak_log.png)
+                [1.0, 1.0], // Side (oak_log.png)
+                [1.0, 1.0], // Side (oak_log.png)
+                [2.0, 1.0], // Top (oak_log_top.png)
+                [2.0, 1.0], // Bottom (oak_log_top.png)
             ],
-            BlockType::OakLeaves => [[4.0, 3.0]; 6],
+            BlockType::OakLeaves => [[0.0, 2.0]; 6], // oak_leaves.png
         }
     }
 }

--- a/engine/src/main.rs
+++ b/engine/src/main.rs
@@ -389,18 +389,18 @@ impl State {
             source: wgpu::ShaderSource::Wgsl(include_str!("shader.wgsl").into()),
         });
 
-        const TERRAIN_ATLAS_BYTES: &[u8] = include_bytes!("../assets/resources/terrain.png");
+        const TERRAIN_ATLAS_BYTES: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/terrain_atlas.png"));
 
         let diffuse_texture = match crate::texture::Texture::load_from_memory(
             &device,
             &queue,
             TERRAIN_ATLAS_BYTES,
-            "terrain_atlas_from_memory",
+            "terrain_atlas.png",
         ) {
             Ok(tex) => tex,
             Err(e) => {
                 eprintln!(
-                    "Failed to load embedded terrain.png from memory: {}. Using placeholder.",
+                    "Failed to load generated terrain_atlas.png from memory: {}. Using placeholder.",
                     e
                 );
                 crate::texture::Texture::create_placeholder(


### PR DESCRIPTION
This commit introduces a build script that generates a texture atlas from individual block textures at build time.

The new `engine/build.rs` script:
- Reads all `.png` files from `engine/assets/textures/block/`.
- Stitches them into a single texture atlas.
- Saves the generated atlas to `$OUT_DIR/terrain_atlas.png`.

The main application has been updated to load the generated texture atlas from the `OUT_DIR` at compile time.

The texture coordinates in `engine/src/block.rs` have been updated to match the new atlas layout.